### PR TITLE
Cancela opcion de redimensionar ventana

### DIFF
--- a/src/bases/Ayuda.java
+++ b/src/bases/Ayuda.java
@@ -18,6 +18,7 @@ public class Ayuda extends javax.swing.JFrame {
         initComponents();            // componentes de interfaz
         this.setLocationRelativeTo(null);
         setTitle("Manual de usuario"); //Titulo de ventana
+        this.setResizable(false);
     }
 
     /**

--- a/src/bases/Conversor.java
+++ b/src/bases/Conversor.java
@@ -18,6 +18,7 @@ public class Conversor extends javax.swing.JFrame {
         initComponents();           //Componentes graficos
         this.setLocationRelativeTo(null);
         setTitle("Convsersiones Númericas"); //Titulo de ventana
+        this.setResizable(false);
     }  
     @SuppressWarnings("unchecked")
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents

--- a/src/bases/Inicio.java
+++ b/src/bases/Inicio.java
@@ -15,6 +15,7 @@ public class Inicio extends javax.swing.JFrame {
         setTitle("Inicio");         //Título de la ventana 
         initComponents();           //Componentes gráficos
         this.setLocationRelativeTo(null);
+        this.setResizable(false); //Cancela la opcion de cambiar el tamaño de la ventana
     }
     /**
      * This method is called from within the constructor to initialize the form.


### PR DESCRIPTION
Añadí el método setResizable  como false para que no se pueda expandir la ventana debido a que al hacerlo los componentes no se adaptan al cambio. Esto se puede cambiar, es decir que se adapten automáticamente pero creí que seria mas sencillo NO poder modificar las ventanas. 👍 